### PR TITLE
Feature/integrate user management

### DIFF
--- a/event_radar/lib/core/models/event.dart
+++ b/event_radar/lib/core/models/event.dart
@@ -12,6 +12,7 @@ class Event {
   final String creatorId;
   final bool promoted;
   final int participantCount;
+  final List<String> participants;
 
   Event({
     this.id,
@@ -25,12 +26,13 @@ class Event {
     required this.creatorId,
     required this.promoted,
     this.participantCount = 0,
+    required this.participants,
   });
 
   Map<String, dynamic> toMap() {
     final map = {
       'title': title,
-      'date': startDate, // Named Date because if no Enddate is selected this represents the date of the event.
+      'date': startDate,
       'location': location,
       'visibility': visibility,
       'description': description,
@@ -39,6 +41,7 @@ class Event {
       'creatorId': creatorId,
       'promoted': promoted,
       'participantCount': participantCount,
+      'participants': participants,
     };
     if (endDate != null) {
       map['endDate'] = endDate;
@@ -60,6 +63,10 @@ class Event {
       creatorId: data['creatorId'] ?? 'dummyUserId',
       promoted: data['promoted'] ?? false,
       participantCount: data['participantCount'] ?? 0,
+      participants: (data['participants'] as List<dynamic>?)
+          ?.map((item) => item.toString())
+          .toList() ??
+          [data['creatorId'] ?? 'dummyUserId'],
     );
   }
 }

--- a/event_radar/lib/core/providers/location_provider.dart
+++ b/event_radar/lib/core/providers/location_provider.dart
@@ -8,10 +8,49 @@ class LocationProvider extends ChangeNotifier {
 
   Future<void> updateLocation() async {
     try {
-      _currentPosition = await Geolocator.getCurrentPosition();
-      notifyListeners();
+      // Check the current permission status.
+      LocationPermission permission = await Geolocator.checkPermission();
+
+      // If permission is denied, request it.
+      if (permission == LocationPermission.denied) {
+        permission = await Geolocator.requestPermission();
+      }
+
+      // If permissions are still not granted or are denied forever, use a default position.
+      if (permission == LocationPermission.deniedForever ||
+          (permission != LocationPermission.whileInUse &&
+              permission != LocationPermission.always)) {
+        _currentPosition = Position(
+          latitude: 52.5200,
+          longitude: 13.4050,
+          timestamp: DateTime.now(),
+          accuracy: 1.0,
+          altitude: 0.0,
+          heading: 0.0,
+          speed: 0.0,
+          speedAccuracy: 0,
+          altitudeAccuracy: 0,
+          headingAccuracy: 0,
+        );
+      } else {
+        // If permission is granted, get the current position.
+        _currentPosition = await Geolocator.getCurrentPosition();
+      }
     } catch (e) {
-      print("Error updating location: $e");
+      // In case of an error, also default
+      _currentPosition = Position(
+        latitude: 52.5200,
+        longitude: 13.4050,
+        timestamp: DateTime.now(),
+        accuracy: 1.0,
+        altitude: 0.0,
+        heading: 0.0,
+        speed: 0.0,
+        speedAccuracy: 0,
+        altitudeAccuracy: 0,
+        headingAccuracy: 0,
+      );
     }
+    notifyListeners();
   }
 }

--- a/event_radar/lib/core/services/event_service.dart
+++ b/event_radar/lib/core/services/event_service.dart
@@ -67,10 +67,13 @@ class EventService {
         .map((snapshot) => snapshot.docs.map((doc) => Event.fromDocument(doc)).toList());
   }
 
-  // We will not make this a Stream of Snapshots because this is used for example for the map where
-  // real time updates could just eat performance
   Future<List<Event>> getEvents() async {
     QuerySnapshot snapshot = await _firestore.collection('events').get();
+    return snapshot.docs.map((doc) => Event.fromDocument(doc)).toList();
+  }
+
+  Future<List<Event>> getPublicEvents() async {
+    QuerySnapshot snapshot = await _firestore.collection('events').where('visibility', isEqualTo: 'public').get();
     return snapshot.docs.map((doc) => Event.fromDocument(doc)).toList();
   }
 

--- a/event_radar/lib/core/services/event_service.dart
+++ b/event_radar/lib/core/services/event_service.dart
@@ -59,7 +59,14 @@ class EventService {
     return Event.fromDocument(await eventRef.get());
   }
 
-  /// Retrieves all events from Firestore.
+  Stream<List<Event>> getUserEventsStream(String uid) {
+    return _firestore
+        .collection('events')
+        .where('participants', arrayContains: uid)
+        .snapshots()
+        .map((snapshot) => snapshot.docs.map((doc) => Event.fromDocument(doc)).toList());
+  }
+
   Future<List<Event>> getEvents() async {
     QuerySnapshot snapshot = await _firestore.collection('events').get();
     return snapshot.docs.map((doc) => Event.fromDocument(doc)).toList();

--- a/event_radar/lib/core/utils/image_placeholder.dart
+++ b/event_radar/lib/core/utils/image_placeholder.dart
@@ -1,5 +1,5 @@
-String getInitials(String title) {
-  final words = title.split(' ');
+String getImagePlaceholder(String name) {
+  final words = name.split(' ').take(2);
   String initials = '';
   for (var word in words) {
     if (word.isNotEmpty) {

--- a/event_radar/lib/core/viewmodels/event_creation_viewmodel.dart
+++ b/event_radar/lib/core/viewmodels/event_creation_viewmodel.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:event_radar/core/utils/image_placeholder.dart';
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -7,7 +8,6 @@ import 'package:image_cropper/image_cropper.dart';
 import '../models/event.dart';
 import '../services/auth_service.dart';
 import '../services/event_service.dart';
-import '../utils/initials_helper.dart';
 
 class EventCreationViewModel extends ChangeNotifier {
   final EventService _eventService = EventService();
@@ -17,16 +17,14 @@ class EventCreationViewModel extends ChangeNotifier {
 
   // Form fields
   String title = '';
-  DateTime? dateTime; // Start time or time
+  DateTime? dateTime;
   DateTime? endDateTime;
   LatLng? location;
   String visibility = 'public';
   String description = '';
   bool promoted = false;
 
-  // Image file (cropped)
   File? imageFile;
-  // Fallback: if no image is chosen, we use initials from the title.
   String? imageUrl;
 
   bool validate() {
@@ -61,7 +59,7 @@ class EventCreationViewModel extends ChangeNotifier {
   }
 
   Future<String> createEvent() async {
-    final currentUser = await AuthService().currentUser();
+    final currentUser = AuthService().currentUser();
     if (currentUser == null) {
       throw Exception("User not logged in");
     }
@@ -73,7 +71,7 @@ class EventCreationViewModel extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final image = imageUrl ?? (imageFile != null ? '' : getInitials(title));
+      final image = imageUrl ?? (imageFile != null ? '' : getImagePlaceholder(title));
       final geoPoint = GeoPoint(location!.latitude, location!.longitude);
       final event = Event(
         title: title,

--- a/event_radar/lib/core/viewmodels/event_creation_viewmodel.dart
+++ b/event_radar/lib/core/viewmodels/event_creation_viewmodel.dart
@@ -5,6 +5,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:image_cropper/image_cropper.dart';
 import '../models/event.dart';
+import '../services/auth_service.dart';
 import '../services/event_service.dart';
 import '../utils/initials_helper.dart';
 
@@ -60,6 +61,11 @@ class EventCreationViewModel extends ChangeNotifier {
   }
 
   Future<String> createEvent() async {
+    final currentUser = await AuthService().currentUser();
+    if (currentUser == null) {
+      throw Exception("User not logged in");
+    }
+
     if (!validate()) {
       return 'Bitte alle Felder ausfüllen.';
     }
@@ -77,9 +83,10 @@ class EventCreationViewModel extends ChangeNotifier {
         visibility: visibility,
         description: description.isNotEmpty ? description : null,
         image: image,
-        creatorId: 'dummyUserId', // TODO: Insert the actual user UID
+        creatorId: currentUser.uid,
         promoted: promoted,
-        participantCount: 1, // Upon creation we always have one participant
+        participantCount: 1,
+        participants: [currentUser.uid],
       );
 
       await _eventService.createEvent(event, imageFile: imageFile);

--- a/event_radar/lib/core/viewmodels/event_list_viewmodel.dart
+++ b/event_radar/lib/core/viewmodels/event_list_viewmodel.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../models/event.dart';
+import '../services/auth_service.dart';
 import '../services/event_service.dart';
 
 class EventListViewModel extends ChangeNotifier {
@@ -10,24 +11,13 @@ class EventListViewModel extends ChangeNotifier {
   List<Event> events = [];
   bool isLoading = false;
 
-  EventListViewModel() {
-    fetchEvents();
-  }
-
-  Future<void> fetchEvents() async {
-    isLoading = true;
-    notifyListeners();
-    try {
-      events = await _eventService.getEvents();
-    } catch (e) {
-      print("Error fetching events: $e");
+  Stream<List<Event>> get userEventsStream {
+    final user = AuthService().currentUser();
+    if (user != null) {
+      return _eventService.getUserEventsStream(user.uid);
+    } else {
+      return Stream.value([]);
     }
-    isLoading = false;
-    notifyListeners();
-  }
-
-  Future<void> refreshEvents() async {
-    await fetchEvents();
   }
 
   /// Computes the distance (in km) from the user's current position to the event.

--- a/event_radar/lib/core/viewmodels/event_map_viewmodel.dart
+++ b/event_radar/lib/core/viewmodels/event_map_viewmodel.dart
@@ -4,7 +4,7 @@ import '../services/event_service.dart';
 
 class EventMapViewModel extends ChangeNotifier {
   final EventService _eventService = EventService();
-  List<Event> events = [];
+  List<Event> publicEvents = [];
   bool isLoading = false;
 
   EventMapViewModel() {
@@ -15,8 +15,7 @@ class EventMapViewModel extends ChangeNotifier {
     isLoading = true;
     notifyListeners();
     try {
-      List<Event> allEvents = await _eventService.getEvents();
-      events = allEvents.where((event) => event.visibility == 'public').toList();
+      publicEvents = await _eventService.getPublicEvents();
     } catch (e) {
       print("Error fetching events for map: $e");
     }

--- a/event_radar/lib/main.dart
+++ b/event_radar/lib/main.dart
@@ -89,22 +89,7 @@ class MyApp extends StatelessWidget {
                 path: '/event-overview/:id',
                 builder: (context, state) {
                   final eventId = state.pathParameters['id']!;
-                  return StreamBuilder<Event>(
-                    stream: EventService().getEventStream(eventId),
-                    builder: (context, snapshot) {
-                      if (snapshot.connectionState == ConnectionState.waiting) {
-                        return const Scaffold(
-                          body: Center(child: CircularProgressIndicator()),
-                        );
-                      }
-                      if (snapshot.hasError || !snapshot.hasData) {
-                        return Scaffold(
-                          body: Center(child: Text("Fehler beim Laden des Events")),
-                        );
-                      }
-                      return EventOverviewScreen(event: snapshot.data!);
-                    },
-                  );
+                  return EventOverviewScreen(eventId: eventId);
                 },
               ),
             ],

--- a/event_radar/lib/views/event_list_screen.dart
+++ b/event_radar/lib/views/event_list_screen.dart
@@ -1,3 +1,4 @@
+import 'package:event_radar/core/utils/image_placeholder.dart';
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:go_router/go_router.dart';
@@ -5,7 +6,6 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import '../core/models/event.dart';
 import '../core/viewmodels/event_list_viewmodel.dart';
-import '../core/utils/initials_helper.dart';
 import '../core/providers/location_provider.dart';
 import '../widgets/main_scaffold.dart';
 
@@ -86,7 +86,7 @@ class EventListScreen extends StatelessWidget {
                         ? NetworkImage(event.image)
                         : null,
                     child: (event.image.isEmpty || !event.image.startsWith('http'))
-                        ? Text(getInitials(event.title))
+                        ? Text(getImagePlaceholder(event.title))
                         : null,
                   ),
                   title: Text(event.title),
@@ -101,7 +101,7 @@ class EventListScreen extends StatelessWidget {
                     ],
                   ),
                   onTap: () {
-                    context.push('/event-overview/$index');
+                    context.push('/event-overview/${event.id}');
                   },
                 );
               },

--- a/event_radar/lib/views/event_list_screen.dart
+++ b/event_radar/lib/views/event_list_screen.dart
@@ -1,62 +1,68 @@
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:go_router/go_router.dart';
-import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
-import '../core/viewmodels/event_list_viewmodel.dart';
+import 'package:provider/provider.dart';
 import '../core/models/event.dart';
+import '../core/viewmodels/event_list_viewmodel.dart';
 import '../core/utils/initials_helper.dart';
-import '../widgets/main_scaffold.dart';
 import '../core/providers/location_provider.dart';
+import '../widgets/main_scaffold.dart';
 
 class EventListScreen extends StatelessWidget {
-  const EventListScreen({Key? key}) : super(key: key);
+  const EventListScreen({super.key});
 
-  Future<void> _refreshEvents(BuildContext context) async {
-    await Provider.of<LocationProvider>(
-      context,
-      listen: false,
-    ).updateLocation();
-    await Provider.of<EventListViewModel>(
-      context,
-      listen: false,
-    ).refreshEvents();
-  }
-
-  String formatDateTime(DateTime dt) => DateFormat('dd.MM.yyyy – HH:mm').format(dt);
+  String formatDateTime(DateTime dt) =>
+      DateFormat('dd.MM.yyyy – HH:mm').format(dt);
 
   @override
   Widget build(BuildContext context) {
-    final userPosition = Provider.of<LocationProvider>(context).currentPosition;
+    final locationProvider = Provider.of<LocationProvider>(context);
+    final userPosition = locationProvider.currentPosition;
+
+    if (userPosition == null) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
 
     return MainScaffold(
-      title: 'Events',
+      title: 'Meine Events',
       floatingActionButton: FloatingActionButton(
         onPressed: () {
           context.go('/event-list/create-event');
         },
         child: const Icon(Icons.add),
       ),
-      body: Consumer<EventListViewModel>(
-        builder: (context, viewModel, child) {
-          if (viewModel.isLoading) {
+      body: StreamBuilder<List<Event>>(
+        stream:
+        Provider.of<EventListViewModel>(context, listen: false).userEventsStream,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
             return const Center(child: CircularProgressIndicator());
           }
+          if (snapshot.hasError) {
+            return Center(child: Text("Fehler: ${snapshot.error}"));
+          }
+          final events = snapshot.data;
+          if (events == null || events.isEmpty) {
+            return const Center(child: Text("Keine Events gefunden."));
+          }
           return RefreshIndicator(
-            onRefresh: () => _refreshEvents(context),
+            onRefresh: () async {
+              // Optionally update location here before refreshing, if needed.
+              await locationProvider.updateLocation();
+            },
             child: ListView.builder(
-              itemCount: viewModel.events.length,
+              itemCount: events.length,
               itemBuilder: (context, index) {
-                final Event event = viewModel.events[index];
-                final double distance = userPosition != null
-                    ? (Geolocator.distanceBetween(
+                final event = events[index];
+                final double distance = Geolocator.distanceBetween(
                     userPosition.latitude,
                     userPosition.longitude,
                     event.location.latitude,
                     event.location.longitude) /
-                    1000.0)
-                    : 0.0;
-
+                    1000.0;
                 // Build a subtitle that shows start date, and if applicable the end date on a separate line.
                 Widget dateInfo;
                 if (event.endDate != null) {
@@ -73,10 +79,10 @@ class EventListScreen extends StatelessWidget {
                     style: const TextStyle(fontSize: 12, color: Colors.grey),
                   );
                 }
-
                 return ListTile(
                   leading: CircleAvatar(
-                    backgroundImage: (event.image.isNotEmpty && event.image.startsWith('http'))
+                    backgroundImage: (event.image.isNotEmpty &&
+                        event.image.startsWith('http'))
                         ? NetworkImage(event.image)
                         : null,
                     child: (event.image.isEmpty || !event.image.startsWith('http'))

--- a/event_radar/lib/views/event_map_screen.dart
+++ b/event_radar/lib/views/event_map_screen.dart
@@ -22,15 +22,12 @@ class EventMapScreen extends StatelessWidget {
         icon: BitmapDescriptor.defaultMarkerWithHue(
           event.promoted ? BitmapDescriptor.hueYellow : BitmapDescriptor.hueAzure,
         ),
-        infoWindow: InfoWindow(
-          title: event.title,
-          snippet: event.description ?? '',
-          onTap: () => _showEventDetails(context, event, index),
-        ),
+        onTap: () => _showEventDetails(context, event, index),
       );
     }).toSet();
   }
-
+  // TODO: Berechtigungs abfrage bei start von app Und standard location falls no permission
+// TODO: Fix content shit and stuff -> Warnings clearing
   void _showEventDetails(BuildContext context, Event event, int index) {
     showModalBottomSheet(
       context: context,

--- a/event_radar/lib/views/event_map_screen.dart
+++ b/event_radar/lib/views/event_map_screen.dart
@@ -26,8 +26,6 @@ class EventMapScreen extends StatelessWidget {
       );
     }).toSet();
   }
-  // TODO: Berechtigungs abfrage bei start von app Und standard location falls no permission
-// TODO: Fix content shit and stuff -> Warnings clearing
   void _showEventDetails(BuildContext context, Event event, int index) {
     showModalBottomSheet(
       context: context,
@@ -81,7 +79,7 @@ class EventMapScreen extends StatelessWidget {
             target: LatLng(userPosition.latitude, userPosition.longitude),
             zoom: 15,
           ),
-          markers: _createMarkers(viewModel.events, context),
+          markers: _createMarkers(viewModel.publicEvents, context),
           myLocationEnabled: true,
           zoomControlsEnabled: true,
         );

--- a/event_radar/lib/views/event_map_screen.dart
+++ b/event_radar/lib/views/event_map_screen.dart
@@ -1,3 +1,4 @@
+import 'package:event_radar/core/utils/image_placeholder.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
@@ -5,7 +6,6 @@ import 'package:provider/provider.dart';
 import '../core/providers/location_provider.dart';
 import '../core/viewmodels/event_map_viewmodel.dart';
 import '../core/models/event.dart';
-import '../core/utils/initials_helper.dart';
 import 'package:collection/collection.dart';
 
 class EventMapScreen extends StatelessWidget {
@@ -42,7 +42,7 @@ class EventMapScreen extends StatelessWidget {
                     ? NetworkImage(event.image)
                     : null,
                 child: (event.image.isEmpty || !event.image.startsWith('http'))
-                    ? Text(getInitials(event.title))
+                    ? Text(getImagePlaceholder(event.title))
                     : null,
               ),
               title: Text(event.title),
@@ -50,7 +50,7 @@ class EventMapScreen extends StatelessWidget {
             ),
             ElevatedButton(
               onPressed: () {
-                context.push('/event-overview/$index');
+                context.push('/event-overview/${event.id}');
               },
               child: const Text("Zum Event"),
             ),

--- a/event_radar/lib/views/event_overview_screen.dart
+++ b/event_radar/lib/views/event_overview_screen.dart
@@ -6,6 +6,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../core/models/event.dart';
 import '../core/services/auth_service.dart';
 import '../core/services/event_service.dart';
+import '../widgets/confirm_dialog.dart';
 import '../widgets/main_scaffold.dart';
 import '../widgets/static_map_snippet.dart';
 
@@ -13,33 +14,6 @@ class EventOverviewScreen extends StatelessWidget {
   final String eventId;
 
   const EventOverviewScreen({super.key, required this.eventId});
-
-  Future<bool> _showConfirmationDialog(
-    BuildContext context,
-    String title,
-    String content,
-  ) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (BuildContext dialogContext) {
-        return AlertDialog(
-          title: Text(title),
-          content: Text(content),
-          actions: [
-            TextButton(
-              child: const Text("Abbrechen"),
-              onPressed: () => Navigator.of(dialogContext).pop(false),
-            ),
-            TextButton(
-              child: const Text("Bestätigen"),
-              onPressed: () => Navigator.of(dialogContext).pop(true),
-            ),
-          ],
-        );
-      },
-    );
-    return confirmed ?? false;
-  }
 
   Future<void> _toggleParticipation(
     BuildContext context,
@@ -52,7 +26,7 @@ class EventOverviewScreen extends StatelessWidget {
         isParticipant
             ? "Bist du sicher das du das Event verlassen willst?"
             : "Möchtest du dich bei diesem Event eintragen?";
-    final confirmed = await _showConfirmationDialog(
+    final confirmed = await showConfirmationDialog(
       context,
       confirmTitle,
       confirmContent,

--- a/event_radar/lib/widgets/confirm_dialog.dart
+++ b/event_radar/lib/widgets/confirm_dialog.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+Future<bool> showConfirmationDialog(
+    BuildContext context,
+    String title,
+    String content,
+    ) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (BuildContext dialogContext) {
+      return AlertDialog(
+        title: Text(title),
+        content: Text(content),
+        actions: [
+          TextButton(
+            child: const Text("Abbrechen"),
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+          ),
+          TextButton(
+            child: const Text("Bestätigen"),
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+          ),
+        ],
+      );
+    },
+  );
+  return confirmed ?? false;
+}


### PR DESCRIPTION
Changes:
- Events in der Overview und in der eigenen Eventliste synchronisieren in Echtzeit
- User sehen nurnoch die Events in denen sie sind.
- User bekommt beim joinen normale Rolle, beim Erstellen Organizer rolle
- Events werden nicht mehr nach Index abgerufen was auch nicht mehr funktioniert hätte sondern richtigerweise nach ID
- Ein User kann nun öffentlichen Events beitreten und sie wieder verlassen.
- Screens zeigen nur das an was der User sehen darf (z.B In der Overview werden nachrichtenchannel nicht angezeigt wenn er nicht mitglied ist.)
- Die Oberfläche updatet instant beim verlassen und betreten des Events.
- Location Permissions werden bei App Start abgefragt und wenn keine gegeben werden nehme eine Default Location
- Event hat nun auch eine Liste an Participant IDs. Hintergrund ist das Firebase sehr effektive Querys mit bedingungen machen kann wie zum Beispiel ob in Array Participants die ID drin ist. Aber auf subcollections geht das nicht so effektiv. Die subcollection brauchen wir aber trotzdem da wir hier metadaten wie die Rolle behalten können.
- Auf Public Map ist die suche auch nun effizienter da direkt in der Query auf public gefiltert wird anstatt erst alle Events zu holen und dann zu filtern.