### PR TITLE
feat: limit event title and description length

### DIFF
--- a/event_radar/lib/core/models/event.dart
+++ b/event_radar/lib/core/models/event.dart
@@ -16,6 +16,9 @@ class Event {
 
   static final EventAttributes attr = EventAttributes();
 
+  static int maxTitleLength = 25;
+  static int maxDescriptionLength = 50;
+
   Event({
     this.id,
     required this.title,

--- a/event_radar/lib/views/event_creation_screen.dart
+++ b/event_radar/lib/views/event_creation_screen.dart
@@ -1,3 +1,4 @@
+import 'package:event_radar/core/models/event.dart';
 import 'package:event_radar/widgets/image_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -92,6 +93,7 @@ class _EventCreationScreenState extends State<EventCreationScreen> {
                               decoration: const InputDecoration(
                                 labelText: 'Event Name',
                               ),
+                              maxLength: Event.maxTitleLength,
                               onChanged: (value) => vm.title = value,
                               validator: (value) {
                                 if (value == null || value.isEmpty) {
@@ -151,7 +153,7 @@ class _EventCreationScreenState extends State<EventCreationScreen> {
                         decoration: const InputDecoration(
                           labelText: 'Beschreibung (optional)',
                         ),
-                        maxLines: 3,
+                        maxLength: Event.maxDescriptionLength,
                         onChanged: (value) => vm.description = value,
                       ),
                       const SizedBox(height: 16.0),

--- a/event_radar/lib/views/event_overview_screen.dart
+++ b/event_radar/lib/views/event_overview_screen.dart
@@ -84,26 +84,19 @@ class _EventOverviewContent extends StatelessWidget {
               padding: const EdgeInsets.symmetric(horizontal: 16),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
+                spacing: 10,
                 children: [
-                  const SizedBox(height: 10),
                   _buildDescription(context, vm, event, isOrganizer),
-                  const SizedBox(height: 10),
                   _buildDateTile(context, vm, event, isOrganizer),
-                  const SizedBox(height: 10),
                   _buildParticipantsTile(context, vm, event),
                   if (isParticipant) ...[
-                    const SizedBox(height: 10),
                     _buildAnnouncementsTile(context, vm, chVm, isOrganizer),
-                    const SizedBox(height: 10),
                     _buildChatRoomsSection(context, vm, chVm, isOrganizer),
                   ],
-                  const SizedBox(height: 10),
                   _buildMap(context, vm, event, isOrganizer),
-                  const SizedBox(height: 10),
                   isParticipant
                       ? _buildShareButton(vm.eventId)
                       : _buildJoinButton(context, event, currentUser!.uid),
-                  const SizedBox(height: 10),
                 ],
               ),
             ),
@@ -160,7 +153,10 @@ class _EventOverviewContent extends StatelessWidget {
                           builder:
                               (ctx) => AlertDialog(
                                 title: const Text("Titel ändern"),
-                                content: TextField(controller: controller),
+                                content: TextField(
+                                  controller: controller,
+                                  maxLength: Event.maxTitleLength,
+                                ),
                                 actions: [
                                   TextButton(
                                     child: const Text("Abbrechen"),
@@ -223,7 +219,7 @@ class _EventOverviewContent extends StatelessWidget {
                         title: const Text("Beschreibung ändern"),
                         content: TextField(
                           controller: controller,
-                          maxLines: null,
+                          maxLength: Event.maxDescriptionLength,
                           decoration: const InputDecoration(
                             hintText: "Neue Beschreibung eingeben...",
                           ),


### PR DESCRIPTION
- limit event title length to 25 (which is barely 3 lines with only Ws)
- limit Description length to 50 and disable newlines